### PR TITLE
Replace dash with underscore

### DIFF
--- a/vng_api_common/serializers.py
+++ b/vng_api_common/serializers.py
@@ -69,12 +69,7 @@ class FoutSerializer(serializers.Serializer):
 
 
 class ValidatieFoutSerializer(FoutSerializer):
-    pass
-
-
-# can't declare stuff with dashes and DSO prescribes dashed key...
-ValidatieFoutSerializer._declared_fields['invalid-params'] = \
-    FieldValidationErrorSerializer(source='invalid_params', many=True)
+    invalid_params = FieldValidationErrorSerializer(many=True)
 
 
 def add_choice_values_help_text(choices: DjangoChoices) -> str:

--- a/vng_api_common/tests/schema.py
+++ b/vng_api_common/tests/schema.py
@@ -53,7 +53,7 @@ def get_validation_errors(response, field, index=0):
     """
     assert response.status_code == 400
     i = 0
-    for error in response.data['invalid-params']:
+    for error in response.data['invalid_params']:
         if error['name'] != field:
             continue
 


### PR DESCRIPTION
* with drf-camelcase renderer, this makes it `invalidParams`
* KPI-API decided on this change

Zie https://github.com/Geonovum/KP-APIs/issues/21#issuecomment-467888849 & https://github.com/Geonovum/KP-APIs/pull/149