### PR TITLE
Feature/add ordering filter support

### DIFF
--- a/vng_api_common/conf/api.py
+++ b/vng_api_common/conf/api.py
@@ -44,7 +44,7 @@ BASE_REST_FRAMEWORK = {
     #
     # # Filtering
     # 'SEARCH_PARAM': 'zoek',  # 'search',
-    # 'ORDERING_PARAM': 'sorteer',  # 'ordering',
+    'ORDERING_PARAM': 'ordering',  # 'ordering',
     #
     # Versioning
     'DEFAULT_VERSION': '1',  # NOT to be confused with API_VERSION - it's the major version part

--- a/vng_api_common/inspectors/query.py
+++ b/vng_api_common/inspectors/query.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext as _
 from django_filters.filters import ChoiceFilter
 from drf_yasg import openapi
 from drf_yasg.inspectors.query import CoreAPICompatInspector
+from rest_framework.filters import OrderingFilter
 
 from ..filters import URLModelChoiceFilter
 from ..utils import underscore_to_camel
@@ -18,6 +19,9 @@ class FilterInspector(CoreAPICompatInspector):
 
     def get_filter_parameters(self, filter_backend):
         fields = super().get_filter_parameters(filter_backend)
+        if isinstance(filter_backend, OrderingFilter):
+            return fields
+
         if fields:
             queryset = self.view.get_queryset()
             filter_class = filter_backend.get_filter_class(self.view, queryset)

--- a/vng_api_common/viewsets.py
+++ b/vng_api_common/viewsets.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.settings import api_settings
+from rest_framework.filters import OrderingFilter
 
 from .filters import Backend
 from .utils import lookup_kwargs_to_filters, underscore_to_camel
@@ -53,6 +54,9 @@ class CheckQueryParamsMixin:
                 raise NotImplementedError("Unknown paginator class: %s" % type(self.paginator))
 
         unknown_params = set(request.query_params.keys()) - known_params
+        if OrderingFilter in self.filter_backends:
+            unknown_params.discard(api_settings.ORDERING_PARAM)
+
         if unknown_params:
             msg = _("Onbekende query parameters: %s" % ", ".join(unknown_params))
             raise ValidationError(

--- a/vng_api_common/viewsets.py
+++ b/vng_api_common/viewsets.py
@@ -1,9 +1,9 @@
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.settings import api_settings
-from rest_framework.filters import OrderingFilter
 
 from .filters import Backend
 from .utils import lookup_kwargs_to_filters, underscore_to_camel


### PR DESCRIPTION
Changes:
1. Remove `OrderingFilter` parameter from `unknown_ params` in `CheckQueryParamsMixin`
1. Add `OrderingFilter` to query inspector for correct schema generation