### PR TITLE
use filter.field_name as a model_field in filter inspector

### DIFF
--- a/vng_api_common/inspectors/query.py
+++ b/vng_api_common/inspectors/query.py
@@ -28,7 +28,9 @@ class FilterInspector(CoreAPICompatInspector):
 
             for parameter in fields:
                 filter_field = filter_class.base_filters[parameter.name]
-                model_field = queryset.model._meta.get_field(parameter.name.split('__')[0])
+                parameter_name = parameter.name.split('__')[0]
+                filter_field_name = filter_class.base_filters[parameter_name].field_name.split('__')[0]
+                model_field = queryset.model._meta.get_field(filter_field_name)
 
                 if isinstance(filter_field, URLModelChoiceFilter):
                     parameter.description = _("URL to the related {resource}").format(resource=parameter.name)


### PR DESCRIPTION
**Changes:**
1. To generate schema in case there are custom-made filters retrieve model-field from `filter_class.field_name` instead of `parameter.name`