### PR TITLE
add url to SPEC into REDOC settings

### DIFF
--- a/vng_api_common/conf/api.py
+++ b/vng_api_common/conf/api.py
@@ -98,7 +98,8 @@ BASE_SWAGGER_SETTINGS = {
 }
 
 REDOC_SETTINGS = {
-    'EXPAND_RESPONSES': '200,201'
+    'EXPAND_RESPONSES': '200,201',
+    'SPEC_URL': 'openapi.json'
 }
 
 # See: https://github.com/Rebilly/ReDoc#redoc-options-object


### PR DESCRIPTION
Issue - https://github.com/VNG-Realisatie/gemma-zaken/issues/1159

**Changes:**
1. Change link to downloadable spec in the redoc-ui schema to a file with OAS3 