### PR TITLE
Added validation error handling when trying to check permissions for non-existent objects

### DIFF
--- a/testapp/urls.py
+++ b/testapp/urls.py
@@ -18,6 +18,8 @@ urlpatterns = [
 
     ])),
 
+    path("ref/", include("vng_api_common.urls")),
+
     # this is a hack to get the parameter to show up in the API spec
     # this effectively makes this a wildcard URL, so it should be LAST
     path('<webhooks_path>', NotificationView.as_view()),

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from django.db.models import ObjectDoesNotExist
+from django.utils.translation import ugettext as _
+
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from vng_api_common.permissions import BaseAuthRequired
+
+
+class Permissions(BaseAuthRequired):
+    obj_path = "some_fk"
+
+
+class View(APIView):
+    permission_classes = (Permissions,)
+    action = "create"
+    required_scopes = {"create": "dummy"}
+
+    def post(self, request, *args, **kwargs):
+        raise NotImplementedError
+
+
+def test_failed_db_lookup():
+    factory = APIRequestFactory()
+    request = factory.post('/foo', {'someFk': 'https://example.com/api/v1/bar'}, format="json")
+
+    with patch("vng_api_common.permissions.BaseAuthRequired._get_obj") as m:
+        m.side_effect = ObjectDoesNotExist("not found in DB")
+
+        response = View.as_view()(request)
+
+    assert response.status_code == 400
+    invalid_params = response.data["invalid_params"][0]
+    assert invalid_params == {
+        "name": "someFk",
+        "code": "object-does-not-exist",
+        "reason": _("The object does not exist in the database")
+    }

--- a/vng_api_common/permissions.py
+++ b/vng_api_common/permissions.py
@@ -87,6 +87,8 @@ class BaseAuthRequired(permissions.BasePermission):
                 main_obj = self._get_obj(view, request)
             except ObjectDoesNotExist:
                 raise ValidationError({
+                    # using self.obj_path here ASSUMES that the same serializer is used
+                    # for input as output
                     self.obj_path: ValidationError(
                         _('The object does not exist in the database'),
                         code='object-does-not-exist'


### PR DESCRIPTION
Needed to allow validation on foreign key fields (such as `zaak` in ZRC)