### PR TITLE
Fix error handler for unexpected server errors

### DIFF
--- a/tests/test_server_errors.py
+++ b/tests/test_server_errors.py
@@ -1,0 +1,32 @@
+"""
+Test that server errors generate the appropriate JSON response.
+"""
+from django.utils.translation import ugettext as _
+
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+
+class View(APIView):
+    def get(self, *args, **kwargs):
+        raise Exception("Unexpected")
+
+
+def test_unexpected_exception():
+    factory = APIRequestFactory()
+    request = factory.get('/foo', format="json")
+
+    response = View.as_view()(request)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response["Content-Type"] == "application/problem+json"
+
+    del response.data["instance"]
+    assert response.data == {
+        "type": "http://testserver/ref/fouten/APIException/",
+        "code": "error",
+        "title": _("A server error occurred."),
+        "status": 500,
+        "detail": "Internal Server Error",
+    }

--- a/vng_api_common/compat.py
+++ b/vng_api_common/compat.py
@@ -2,6 +2,14 @@ from typing import Union
 
 from django.http import HttpRequest
 
+try:
+    from raven.contrib.django.raven_compat.models import client as sentry_client
+except ImportError:
+    class Client:
+        def captureException(self):
+            pass
+    sentry_client = Client()
+
 
 def get_header(request: HttpRequest, header: str) -> Union[None, str]:
     """


### PR DESCRIPTION
Currently, an HTTP 500 in the API results in an HTML error page. This
should be JSON too, as it is claimed by the API spec.