### PR TITLE
Fix typo in Wijzgingen

### DIFF
--- a/vng_api_common/audittrails/api/serializers.py
+++ b/vng_api_common/audittrails/api/serializers.py
@@ -5,14 +5,14 @@ from ...serializers import GegevensGroepSerializer, add_choice_values_help_text
 from ..models import AuditTrail
 
 
-class WijzgingenSerializer(GegevensGroepSerializer):
+class WijzigingenSerializer(GegevensGroepSerializer):
     class Meta:
         model = AuditTrail
         gegevensgroep = "wijzigingen"
 
 
 class AuditTrailSerializer(serializers.ModelSerializer):
-    wijzigingen = WijzgingenSerializer()
+    wijzigingen = WijzigingenSerializer()
 
     class Meta:
         model = AuditTrail


### PR DESCRIPTION
Bij het maken van de mappings van ZGW objecten in de `openapi.json` en onze eigen code, viel me op dat er een object was met de naam "Wijzgingen". Dit is de enige plek in de code waar ik dat heb kunnen vinden, dus ik ga ervanuit dat deze fix het probleem oplost. 