### PR TITLE
Feature/clientconfig custom client

### DIFF
--- a/testapp/utils.py
+++ b/testapp/utils.py
@@ -1,0 +1,3 @@
+# Custom function to get client for ClientConfig models
+def get_client(url):
+    return "testclient"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+from django.test import override_settings
+
+import pytest
+
+from vng_api_common.notifications.models import NotificationsConfig
+
+
+@pytest.mark.django_db
+@override_settings(CUSTOM_CLIENT_FETCHER="testapp.utils.get_client")
+def test_notificationsconfig_custom_client():
+    config = NotificationsConfig.get_solo()
+    client = config.get_client()
+    assert client == "testclient"


### PR DESCRIPTION
related OZ issue: https://github.com/open-zaak/open-zaak/issues/610

Adds an option to specify a `CUSTOM_CLIENT_FETCHER`, which is a function that returns the desired client for `ClientConfig` models. This allows `Service.get_client` to be called for OpenZaak

@sergei-maertens wasn't sure whether this PR should be made to stable/1.0.x or to master?