### PR TITLE
Added inspector for HyperlinkedRelatedField

### DIFF
--- a/testapp/models.py
+++ b/testapp/models.py
@@ -23,7 +23,9 @@ class Person(ETagMixin, models.Model):
     address_street = models.CharField(_("street name"), max_length=255)
     address_number = models.CharField(_("house number"), max_length=10)
 
-    address = GegevensGroepType({"street": address_street, "number": address_number}, required=False)
+    address = GegevensGroepType(
+        {"street": address_street, "number": address_number}, required=False
+    )
 
     group = models.ForeignKey("Group", null=True, on_delete=models.CASCADE)
 

--- a/vng_api_common/inspectors/fields.py
+++ b/vng_api_common/inspectors/fields.py
@@ -98,6 +98,29 @@ class HyperlinkedIdentityFieldInspector(FieldInspector):
         return NotHandled
 
 
+class HyperlinkedRelatedFieldInspector(FieldInspector):
+    def field_to_swagger_object(
+        self, field, swagger_object_type, use_references, **kwargs
+    ):
+        SwaggerType, ChildSwaggerType = self._get_partial_types(
+            field, swagger_object_type, use_references, **kwargs
+        )
+
+        if (
+            isinstance(field, serializers.HyperlinkedRelatedField)
+            and swagger_object_type == openapi.Schema
+        ):
+            return SwaggerType(
+                type=openapi.TYPE_STRING,
+                format=openapi.FORMAT_URI,
+                min_length=1,
+                max_length=1000,
+                description=field.help_text,
+            )
+
+        return NotHandled
+
+
 class GegevensGroepInspector(FieldInspector):
     def process_result(self, result, method_name, obj, **kwargs):
         if not isinstance(result, openapi.Schema.OR_REF):


### PR DESCRIPTION
required for https://github.com/VNG-Realisatie/verzoeken-api/pull/4
related issue: https://github.com/VNG-Realisatie/gemma-zaken/issues/1405#issuecomment-639543611

@sergei-maertens `in_te_trekken_verzoek` was missing the `min_length` and `max_length` ([1 .. 1000]) in the API spec, I'm not sure if this is where I should add it though.