### PR TITLE
Added inspector for HyperlinkedRelatedField

### DIFF
--- a/vng_api_common/apps.py
+++ b/vng_api_common/apps.py
@@ -62,6 +62,10 @@ def register_serializer_field():
 
 
 def set_custom_hyperlinkedmodelserializer_field():
+    """
+    Monkey-patches Django Rest Framework to avoid having to set the
+    `serializer_related_field` manually for all the base classes in the code
+    """
     serializers.HyperlinkedModelSerializer.serializer_related_field = (
         LengthHyperlinkedRelatedField
     )

--- a/vng_api_common/apps.py
+++ b/vng_api_common/apps.py
@@ -10,7 +10,7 @@ from drf_yasg.inspectors.field import (
 from rest_framework import serializers
 
 from . import fields
-from .serializers import DurationField
+from .serializers import DurationField, LengthHyperlinkedRelatedField
 
 try:
     from relativedeltafield import RelativeDeltaField
@@ -31,6 +31,7 @@ class ZDSSchemaConfig(AppConfig):
 
         patch_duration_type()
         register_serializer_field()
+        set_custom_hyperlinkedmodelserializer_field()
 
 
 def patch_duration_type():
@@ -58,3 +59,9 @@ def register_serializer_field():
 
     if RelativeDeltaField is not None:
         mapping[RelativeDeltaField] = DurationField
+
+
+def set_custom_hyperlinkedmodelserializer_field():
+    serializers.HyperlinkedModelSerializer.serializer_related_field = (
+        LengthHyperlinkedRelatedField
+    )

--- a/vng_api_common/inspectors/fields.py
+++ b/vng_api_common/inspectors/fields.py
@@ -110,8 +110,8 @@ class HyperlinkedRelatedFieldInspector(FieldInspector):
             isinstance(field, LengthHyperlinkedRelatedField)
             and swagger_object_type == openapi.Schema
         ):
-            max_length = getattr(field, "max_length", None)
-            min_length = getattr(field, "min_length", None)
+            max_length = field.max_length
+            min_length = field.min_length
             return SwaggerType(
                 type=openapi.TYPE_STRING,
                 format=openapi.FORMAT_URI,

--- a/vng_api_common/inspectors/fields.py
+++ b/vng_api_common/inspectors/fields.py
@@ -5,7 +5,7 @@ from drf_yasg.inspectors.base import NotHandled
 from drf_yasg.inspectors.field import FieldInspector, InlineSerializerInspector
 from rest_framework import serializers
 
-from ..serializers import GegevensGroepSerializer
+from ..serializers import GegevensGroepSerializer, LengthHyperlinkedRelatedField
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,31 @@ class HyperlinkedIdentityFieldInspector(FieldInspector):
                 min_length=1,
                 max_length=1000,
                 description="URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.",
+            )
+
+        return NotHandled
+
+
+class HyperlinkedRelatedFieldInspector(FieldInspector):
+    def field_to_swagger_object(
+        self, field, swagger_object_type, use_references, **kwargs
+    ):
+        SwaggerType, ChildSwaggerType = self._get_partial_types(
+            field, swagger_object_type, use_references, **kwargs
+        )
+
+        if (
+            isinstance(field, LengthHyperlinkedRelatedField)
+            and swagger_object_type == openapi.Schema
+        ):
+            max_length = getattr(field, "max_length", None)
+            min_length = getattr(field, "min_length", None)
+            return SwaggerType(
+                type=openapi.TYPE_STRING,
+                format=openapi.FORMAT_URI,
+                min_length=min_length,
+                max_length=max_length,
+                description=field.help_text,
             )
 
         return NotHandled

--- a/vng_api_common/serializers.py
+++ b/vng_api_common/serializers.py
@@ -264,3 +264,34 @@ class NestedGegevensGroepMixin:
                 continue
             setattr(instance, name, validated_data.pop(name))
         return super().update(instance, validated_data)
+
+
+class LengthHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+    def __init__(self, *args, **kwargs):
+        self.min_length = kwargs.pop("min_length", None)
+        self.max_length = kwargs.pop("max_length", None)
+        kwargs.setdefault("allow_null", True)
+
+        super().__init__(*args, **kwargs)
+
+    def to_internal_value(self, data):
+        if self.max_length and len(data) > self.max_length:
+            self.fail("max_length", max_length=self.max_length, length=len(data))
+
+        if self.min_length and len(data) < self.min_length:
+            self.fail("min_length", max_length=self.min_length, length=len(data))
+
+        # check if url is valid
+        try:
+            value = super().to_internal_value(data)
+        except ValidationError as field_exc:
+            # rewrite validation code to make it fit reference implementation
+            # if url is not valid
+            try:
+                URLValidator()(data)
+            except ValidationError as exc:
+                self.fail("bad-url", url=data, exc=exc)
+
+            # if the url is not bad -> then the problem is that it doesn't fit resource
+            self.fail("invalid-resource", exc=field_exc)
+        return value


### PR DESCRIPTION
required for https://github.com/VNG-Realisatie/verzoeken-api/pull/4
related issue: https://github.com/VNG-Realisatie/gemma-zaken/issues/1405#issuecomment-639543611

@sergei-maertens `in_te_trekken_verzoek` was missing the `min_length` and `max_length` ([1 .. 1000]) in the API spec, I'm not sure if this is where I should add it though.