### PR TITLE
Fixed FilterInspector help_text for reverse OneToOne

### DIFF
--- a/vng_api_common/inspectors/query.py
+++ b/vng_api_common/inspectors/query.py
@@ -33,8 +33,9 @@ class FilterInspector(CoreAPICompatInspector):
                 parameter._filter_field = filter_field
 
                 help_text = filter_field.extra.get(
-                    "help_text", None
-                ) or model_field.help_text if model_field else ""
+                    "help_text",
+                    getattr(model_field, "help_text", "") if model_field else ""
+                )
 
                 if isinstance(filter_field, URLModelChoiceFilter):
                     description = _("URL to the related {resource}").format(

--- a/vng_api_common/inspectors/query.py
+++ b/vng_api_common/inspectors/query.py
@@ -33,8 +33,8 @@ class FilterInspector(CoreAPICompatInspector):
                 parameter._filter_field = filter_field
 
                 help_text = filter_field.extra.get(
-                    "help_text", model_field.help_text if model_field else ""
-                )
+                    "help_text", None
+                ) or model_field.help_text if model_field else ""
 
                 if isinstance(filter_field, URLModelChoiceFilter):
                     description = _("URL to the related {resource}").format(


### PR DESCRIPTION
required for https://github.com/VNG-Realisatie/klantinteracties-api/pull/26

issue occurred when trying to generate schema for a filter on the reverse of a OneToOneField (which doesn't have a`help_text`)