### PR TITLE
Update kwargs.get call

### DIFF
--- a/vng_api_common/routers.py
+++ b/vng_api_common/routers.py
@@ -26,7 +26,7 @@ class ZDSNestedRegisteringMixin:
         if not nested:
             return
 
-        base_name = kwargs.get("base_name", self.get_default_base_name(viewset))
+        base_name = kwargs.get("base_name") or self.get_default_base_name(viewset)
 
         self._nested_router = NestedSimpleRouter(
             self, prefix, lookup=base_name, trailing_slash=False


### PR DESCRIPTION
A bit of an odd quirk on python's dictionary get method is that a function specified in the second argument is run even if the key exists in the dictionary.

Eg.
```
>>> a_dict = {'key': 'value'}
>>> def print_thing():
...   print('thing')
... 
>>> a_dict.get('key', print_thing())
thing
'value'
>>> 
```

since it's better that get_default_base_name only runs when it's needed, since it can raise an exception,  I think it's better to use `or` in this case.

I didn't add any unit tests for this PR because it would only be testing python's built in functionality but if you think a unit test or two would be useful I can add it. 