### PR TITLE
Allow getting api-root without version

### DIFF
--- a/vng_api_common/management/commands/generate_swagger.py
+++ b/vng_api_common/management/commands/generate_swagger.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string
-from django.urls import reverse, NoReverseMatch
+from django.urls import NoReverseMatch, reverse
 from django.utils.module_loading import import_string
 
 from drf_yasg import openapi

--- a/vng_api_common/management/commands/generate_swagger.py
+++ b/vng_api_common/management/commands/generate_swagger.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string
-from django.urls import reverse
+from django.urls import reverse, NoReverseMatch
 from django.utils.module_loading import import_string
 
 from drf_yasg import openapi
@@ -112,7 +112,11 @@ class Command(generate_swagger.Command):
                 format = "yaml"
         format = format or "json"
 
-        api_root = reverse("api-root", kwargs={"version": get_major_version()})
+        try:
+            api_root = reverse("api-root", kwargs={"version": get_major_version()})
+        except NoReverseMatch:
+            api_root = reverse("api-root")
+
         api_url = (
             api_url
             or swagger_settings.DEFAULT_API_URL  # noqa


### PR DESCRIPTION
I'm using this in a project that does not have versioned APIs so `api_root = reverse("api-root", kwargs={"version": get_major_version()})` throws an exception.  It would be nice if this also worked with non-versioned apis.

This is just one possible solution to this but I'm sure there are other ways to do this.  Let me know if you prefer a different solution :) 