### PR TITLE
:bug: Prevent exception when status is not a digit

### DIFF
--- a/vng_api_common/management/commands/patch_error_contenttypes.py
+++ b/vng_api_common/management/commands/patch_error_contenttypes.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                     continue
 
                 for status, response in method["responses"].items():
-                    if not (400 <= int(status) < 600):
+                    if status.isdigit() and not (400 <= int(status) < 600):
                         continue
 
                     content = {}


### PR DESCRIPTION
Swagger does allow non-numeric status codes (see 'default' at the bottom of one of these endpoints https://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/specificatie/openapi.yaml#/)

Since Swagger allows this we should handle this situation in when generating our schemas. 