### PR TITLE
Pluggable credentials provider

### DIFF
--- a/vng_api_common/client.py
+++ b/vng_api_common/client.py
@@ -1,0 +1,40 @@
+"""
+Interface to get a zds_client object for a given URL.
+"""
+from typing import Optional
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from zds_client import Client
+
+from .models import APICredential
+
+
+def get_client(api_root_url: str) -> Optional[Client]:
+    """
+    Get a client instance for the given URL.
+
+    If the setting CUSTOM_CLIENT_FETCHER is defined, then this callable is invoked.
+    Otherwise we fall back on the default implementation.
+
+    If no suitable client is found, ``None`` is returned.
+    """
+    custom_client_fetcher = getattr(settings, "CUSTOM_CLIENT_FETCHER", None)
+    if custom_client_fetcher:
+        client_getter = import_string(custom_client_fetcher)
+        return client_getter(api_root_url)
+
+    # default implementation
+    Client = import_string(settings.ZDS_CLIENT_CLASS)
+
+    if not api_root_url.endswith("/"):
+        api_root_url = f"{api_root_url}/"
+
+    client = Client.from_url(api_root_url)
+    if client is None:
+        return None
+
+    client.base_url = api_root_url
+    client.auth = APICredential.get_auth(api_root_url)
+    return client

--- a/vng_api_common/notifications/handlers.py
+++ b/vng_api_common/notifications/handlers.py
@@ -1,14 +1,11 @@
 import logging
 
-from django.conf import settings
-from django.utils.module_loading import import_string
-
 from djangorestframework_camel_case.util import underscoreize
 
 from ..authorizations.models import Applicatie
 from ..authorizations.serializers import ApplicatieUuidSerializer
+from ..client import get_client
 from ..constants import CommonResourceAction
-from ..models import APICredential
 from ..utils import get_uuid_from_path
 
 
@@ -20,9 +17,7 @@ class LoggingHandler:
 
 class AuthHandler:
     def _request_auth(self, url: str) -> dict:
-        Client = import_string(settings.ZDS_CLIENT_CLASS)
-        client = Client.from_url(url)
-        client.auth = APICredential.get_auth(url)
+        client = get_client(url)
         response = client.retrieve("applicatie", url)
         return underscoreize(response)
 

--- a/vng_api_common/notifications/management/commands/register_kanaal.py
+++ b/vng_api_common/notifications/management/commands/register_kanaal.py
@@ -4,10 +4,8 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from django.urls import reverse
-from django.utils.module_loading import import_string
 
-from ....models import APICredential
-from ...constants import SCOPE_NOTIFICATIES_PUBLICEREN_LABEL
+from ....client import get_client
 from ...kanalen import KANAAL_REGISTRY
 from ...models import NotificationsConfig
 
@@ -22,16 +20,7 @@ def create_kanaal(api_root: str, kanaal: str) -> None:
     """
     Create a kanaal, if it doesn't exist yet.
     """
-    Client = import_string(settings.ZDS_CLIENT_CLASS)
-
-    if not api_root.endswith("/"):
-        api_root = f"{api_root}/"
-
-    client = Client.from_url(api_root)
-    client.base_url = api_root
-    client.auth = APICredential.get_auth(
-        api_root, scopes=[SCOPE_NOTIFICATIES_PUBLICEREN_LABEL]
-    )
+    client = get_client(api_root, url_is_api_root=True)
 
     # look up the exchange in the registry
     _kanaal = next(k for k in KANAAL_REGISTRY if k.label == kanaal)

--- a/vng_api_common/utils.py
+++ b/vng_api_common/utils.py
@@ -8,9 +8,10 @@ from django.conf import settings
 from django.db import models
 from django.http import HttpRequest
 from django.urls import Resolver404, get_resolver, get_script_prefix
-from django.utils.module_loading import import_string
 
 from zds_client.client import ClientError
+
+from .client import get_client
 
 try:
     from djangorestframework_camel_case.util import (
@@ -124,11 +125,8 @@ def get_uuid_from_path(path: str) -> str:
 def request_object_attribute(
     url: str, attribute: str, resource: Union[str, None] = None
 ) -> str:
-    from .models import APICredential
+    client = get_client(url)
 
-    Client = import_string(settings.ZDS_CLIENT_CLASS)
-    client = Client.from_url(url)
-    client.auth = APICredential.get_auth(url)
     try:
         result = client.retrieve(resource, url=url)[attribute]
     except (ClientError, KeyError) as exc:

--- a/vng_api_common/validators.py
+++ b/vng_api_common/validators.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 import requests
 from rest_framework import serializers, validators
 
+from .client import get_client
 from .constants import RSIN_LENGTH
 from .oas import fetcher, obj_has_shape
 
@@ -239,14 +240,11 @@ class ObjectInformatieObjectValidator:
         self.request = serializer.context["request"]
 
     def __call__(self, informatieobject: str):
-        from .models import APICredential
-
         object_url = self.parent_object.get_absolute_api_url(self.request)
 
         # dynamic so that it can be mocked in tests easily
-        Client = import_string(settings.ZDS_CLIENT_CLASS)
-        client = Client.from_url(informatieobject)
-        client.auth = APICredential.get_auth(informatieobject)
+        client = get_client(informatieobject)
+
         try:
             oios = client.list(
                 "objectinformatieobject",


### PR DESCRIPTION
Change initiated by https://github.com/open-zaak/open-zaak/pull/739

We want to consistently be able to use zgw_consumers as client/credentials provider rather than `vng_api_common.APICredential`.