### PR TITLE
:bookmark: Release version 1.5.10

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 1.5.9
+current_version = 1.5.10
 
 [bumpversion:file:setup.cfg]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vng-api-common",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vng-api-common",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "NodeJS build tooling for vng-api-common",
   "main": "index.js",
   "directories": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # see http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = vng-api-common
-version = 1.5.9
+version = 1.5.10
 description = VNG API tooling
 long_description = file: README.rst
 url = https://github.com/VNG-Realisatie/vng-api-common

--- a/vng_api_common/permissions.py
+++ b/vng_api_common/permissions.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, TYPE_CHECKING
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -10,15 +10,17 @@ from rest_framework import permissions
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.request import Request
 from rest_framework.serializers import ValidationError
-from rest_framework.views import APIView
-from rest_framework.viewsets import ViewSetMixin
 
 from .scopes import Scope
 from .utils import get_resource_for_path
 
+if TYPE_CHECKING:
+    from rest_framework.views import APIView # noqa
+    from rest_framework.viewsets import ViewSetMixin # noqa
+
 
 def get_required_scopes(
-    request: Request, view: Union[APIView, ViewSetMixin]
+    request: Request, view: Union["APIView", "ViewSetMixin"]
 ) -> Union[Scope, None]:
     if not hasattr(view, "required_scopes"):
         raise ImproperlyConfigured(
@@ -33,6 +35,8 @@ def get_required_scopes(
     # auto-generated head method doesn't get an action assigned
     if action is None and detail and view.request.method == "HEAD":
         action = "retrieve"
+
+    from rest_framework.viewsets import ViewSetMixin
 
     # if action is not set, fall back to the request method
     if action is None and not isinstance(view, ViewSetMixin):
@@ -129,7 +133,7 @@ class BaseAuthRequired(permissions.BasePermission):
         return getattr(main_obj, field)
 
     def _has_create_permission(
-        self, request: Request, view: APIView, scopes_required: Scope
+        self, request: Request, view: "APIView", scopes_required: Scope
     ) -> bool:
         try:
             main_obj = self._get_obj(view, request)


### PR DESCRIPTION
because 1.5.9 on PyPI has migration conflicts

@sergei-maertens I think 1.5.9 and 1.0.55 should be yanked on PyPI, but I'm not sure how that works/whether or not I have the permissions to do that