### PR TITLE
Support PyJWT 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     django-rest-framework-condition
     drf-yasg>=1.20.0
     drf-nested-routers>=0.93.3
-    gemma-zds-client>=0.13.0
+    gemma-zds-client>=0.14.0
     iso-639
     isodate
     oyaml

--- a/vng_api_common/tests/auth.py
+++ b/vng_api_common/tests/auth.py
@@ -2,11 +2,11 @@ import time
 from typing import List, Optional
 
 from rest_framework import status
+from zds_client.compat import jwt_encode
 
 from ..authorizations.models import Applicatie, AuthorizationsConfig, Autorisatie
 from ..constants import VertrouwelijkheidsAanduiding
 from ..models import JWTSecret
-from .compat import jwt_encode
 
 
 class AuthCheckMixin:

--- a/vng_api_common/tests/compat.py
+++ b/vng_api_common/tests/compat.py
@@ -1,9 +1,0 @@
-import jwt as _jwt
-
-if _jwt.__version__ >= "2.0.0":
-    jwt_encode = _jwt.encode
-else:
-
-    def jwt_encode(*args, **kwargs) -> str:
-        encoded = _jwt.encode(*args, **kwargs)
-        return encoded.decode()  # bytestring to string


### PR DESCRIPTION
Fixes #175

Uses the compat layer from gemma-zds-client, so the dependency was
bumped to a newer minimal version.