### PR TITLE
Patch error responses which are not defined in spec's components section

### DIFF
--- a/vng_api_common/management/commands/patch_error_contenttypes.py
+++ b/vng_api_common/management/commands/patch_error_contenttypes.py
@@ -19,6 +19,15 @@ class Command(BaseCommand):
             "api-spec", help="Path to the openapi spec. Will be overwritten!"
         )
 
+    def patch_response(self, response):
+        content = {}
+
+        for contenttype, _response in response["content"].items():
+            contenttype = ERROR_CONTENT_TYPE
+            content[contenttype] = _response
+
+        response["content"] = content
+
     def handle(self, **options):
         source = options["api-spec"]
 
@@ -27,17 +36,25 @@ class Command(BaseCommand):
         with open(source, "r", encoding="utf8") as infile:
             spec = yaml.safe_load(infile)
 
+            for endpoint in spec["paths"].values():
+                for data in endpoint.values():
+                    # filter the available request methods
+                    if not "responses" in data:
+                        continue
+
+                    for status, response in data["responses"].items():
+                        # Only edit the error responses which are defined directly
+                        # and not referencing existing error responses
+                        if not (400 <= int(status) < 600) or not "content" in response:
+                            continue
+
+                        self.patch_response(response)
+
             for status, response in spec["components"]["responses"].items():
                 if not (400 <= int(status) < 600):
                     continue
 
-                content = {}
-                for contenttype, _response in response["content"].items():
-                    if contenttype == "application/json":
-                        contenttype = ERROR_CONTENT_TYPE
-                    content[contenttype] = _response
-
-                response["content"] = content
+                self.patch_response(response)
 
         with open(source, "w", encoding="utf8") as outfile:
             yaml.dump(spec, outfile, default_flow_style=False)


### PR DESCRIPTION
In verband met wijzigingen gevraagd in de [openstaande PR](https://github.com/VNG-Realisatie/documenten-api/pull/160#pullrequestreview-976640503) voor de documenten-API om `1.1.0` te releasen.